### PR TITLE
Increase arch compatibility by removing automatic download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 *~
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cp_sat"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2018"
 description = "Rust bindings to the Google CP-SAT constraint programming solver."
 documentation = "https://docs.rs/cp_sat"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ Rust bindings to the Google CP-SAT constraint programming solver.
 
 ## Prerequisites
 - A C++ compiler (e.g. clang)
-- protobuf compiler + libprotobuf
+- [ortools](https://github.com/google/or-tools) v9.14 and its dependencies
 
-Invoke Cargo using `RUSTFLAGS='-Clink-arg=-lprotobuf' cargo <command>`.
-The environment variable `ORTOOLS_PREFIX` is used to find include files and library files. If not setted, `/opt/ortools` will be added to the search path (classical search path will also be used).
+The crate will search for the ortools library in default locations for your platform. If you installed ortools in a
+custom location, set the `OR_TOOLS_LIB_DIR` and `OR_TOOLS_INCLUDE_DIR` environment variables.
+
+## Limitations
+
+If protobuf is not installed in a default location for your system, you will need to manually set the correct flag for
+`rustc` to find it.
+
+Only Linux and macOS are supported.

--- a/build.rs
+++ b/build.rs
@@ -124,5 +124,8 @@ fn main() -> anyhow::Result<()> {
             .compile("cp_sat_wrapper.a");
     }
 
+    println!("cargo:rustc-link-lib=ortools");
+    println!("cargo:rustc-link-lib=protobuf");
+
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -54,6 +54,7 @@ fn find_or_tools_linux() -> anyhow::Result<Option<PathBuf>> {
 /// Finds the OR Tools library directory, adds it to the linker search path, and returns the include
 /// directory.
 fn find_or_tools(target: &str) -> anyhow::Result<PathBuf> {
+    println!("cargo:rerun-if-env-changed=OR_TOOLS_LIB_DIR");
     let custom_lib_dir = if let Some(lib_dir) = std::env::var("OR_TOOLS_LIB_DIR").ok() {
         println!("cargo:rustc-link-search=native={lib_dir}");
         true

--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,17 @@ use anyhow::{anyhow, bail, Context};
 use std::path::{Path, PathBuf};
 
 fn find_or_tools_homebrew() -> anyhow::Result<Option<PathBuf>> {
-    const OR_TOOLS_HOMEBREW_DIR: &str = "/opt/homebrew/opt/or-tools";
+    const OR_TOOLS_HOMEBREW_DIR: [&str; 2] = [
+        "/opt/homebrew/opt/or-tools",
+        "/opt/homebrew/opt/or-tools@9.14",
+    ];
     const OR_TOOLS_HOMEBREW_INCLUDE_DIR: &str = "/opt/homebrew/include";
-    if std::fs::exists(OR_TOOLS_HOMEBREW_DIR)
-        .context("Failed to check if homebrew libortools directory exists")?
-    {
-        return Ok(Some(PathBuf::from(OR_TOOLS_HOMEBREW_INCLUDE_DIR)));
+    for path in OR_TOOLS_HOMEBREW_DIR.iter() {
+        if std::fs::exists(path)
+            .context("Failed to check if homebrew libortools directory exists")?
+        {
+            return Ok(Some(PathBuf::from(OR_TOOLS_HOMEBREW_INCLUDE_DIR)));
+        }
     }
 
     Ok(None)
@@ -124,6 +129,7 @@ fn main() -> anyhow::Result<()> {
     let include_dir = find_or_tools(&target)?;
 
     if std::env::var("DOCS_RS").is_err() {
+        println!("cargo:rerun-if-changed=src/cp_sat_wrapper.cpp");
         cc::Build::new()
             .cpp(true)
             .flags(["-std=c++17", "-DOR_PROTO_DLL="])

--- a/build.rs
+++ b/build.rs
@@ -17,17 +17,18 @@ fn find_or_tools_linux() -> anyhow::Result<Option<PathBuf>> {
     // Since OR Tools does not provide a pkg-config integration, we are left finding it manually
     // using heuristics. OR Tools has the lib inside the lib64 directory.
     const OR_TOOLS_LIB_PATHS: [&str; 6] = [
-        "/usr/local/lib64/libortools.so",
-        "/usr/local/lib/libortools.so",
-        "/usr/lib64/libortools.so",
-        "/usr/lib/libortools.so",
-        "/lib/libortools.so",
-        "/lib64/libortools.so",
+        "/usr/local/lib64",
+        "/usr/local/lib",
+        "/usr/lib64",
+        "/usr/lib",
+        "/lib",
+        "/lib64",
     ];
 
     let mut lib_found = false;
     for path in OR_TOOLS_LIB_PATHS.iter() {
-        if std::fs::exists(path).context("Failed to check if libortools exists")? {
+        let lib_path = Path::new(path).join("libortools.so");
+        if std::fs::exists(lib_path).context("Failed to check if libortools exists")? {
             println!("cargo:rustc-link-search=native={path}");
             lib_found = true;
             break;

--- a/build.rs
+++ b/build.rs
@@ -55,6 +55,7 @@ fn find_or_tools_linux() -> anyhow::Result<Option<PathBuf>> {
 /// directory.
 fn find_or_tools(target: &str) -> anyhow::Result<PathBuf> {
     println!("cargo:rerun-if-env-changed=OR_TOOLS_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=OR_TOOLS_INCLUDE_DIR");
     let custom_lib_dir = if let Some(lib_dir) = std::env::var("OR_TOOLS_LIB_DIR").ok() {
         println!("cargo:rustc-link-search=native={lib_dir}");
         true
@@ -68,6 +69,11 @@ fn find_or_tools(target: &str) -> anyhow::Result<PathBuf> {
         return Ok(PathBuf::from(
             custom_include_dir.expect("include dir should be set"),
         ));
+    } else if custom_lib_dir || custom_include_dir.is_some() {
+        println!(
+            "cargo::error='OR_TOOLS_LIB_DIR' and 'OR_TOOLS_INCLUDE_DIR' must be set together."
+        );
+        bail!("'OR_TOOLS_LIB_DIR' and 'OR_TOOLS_INCLUDE_DIR' must be set together.");
     }
 
     if target.ends_with("-apple-darwin") {


### PR DESCRIPTION
Downloading the correct dependency for every platform is complex, especially since things like cross-compilation are a thing and since one needs to actually know the Linux distro the library is built for. The linux distro is not readily available as an environment variable set by Cargo, instead one has to figure it out a different way. But even then, the vast number of possible combinations makes it impractical to offer an automatic download for everything. Therefore, the automatic download is removed and the burden is moved to the user to make the or-tools library available. Also, since the library is dynamically linked, it usually needs to be provided by the user anyway in the target environment.

For better user experience the build script will try to find the library in default locations and notify the user if this fails. Also, a set of env variables is introduced which allows manually providing a lib and include directory for or-tools.