### PR TITLE
Add homebrew lib path to linker search directories

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,6 +87,7 @@ fn find_or_tools(target: &str) -> anyhow::Result<PathBuf> {
                 if let Some(include_dir) = find_or_tools_homebrew()
                     .context("Failed to check if homebrew libortools directory exists")?
                 {
+                    println!("cargo:rustc-link-search=/opt/homebrew/lib");
                     return Ok(include_dir);
                 }
             }


### PR DESCRIPTION
When we are building for MacOS where or tools was found with homebrew we want to provide the linker search path as well, so that we don't have to manually fiddle with `RUSTFLAGS`